### PR TITLE
Hotfix for "'Cannot read property 'tagName' of undefined'" on html5.1 branch

### DIFF
--- a/multipage.js
+++ b/multipage.js
@@ -116,8 +116,7 @@ for(var i=0; i<sections.length; i++) {
 
   // find the proper section
   section.node = header.parent();
-  //while (section.node.get(0).tagName !== "section") {
-  while (section.node.get(0) && section.node.get(0).tagName !== "section") {
+  while (typeof section.node[0] !== 'undefined' && section.node.get(0).tagName !== "section") {
     section.node = section.node.parent();
   }
   // for section 4, only keep the first subsection

--- a/multipage.js
+++ b/multipage.js
@@ -116,7 +116,8 @@ for(var i=0; i<sections.length; i++) {
 
   // find the proper section
   section.node = header.parent();
-  while (section.node.get(0).tagName !== "section") {
+  //while (section.node.get(0).tagName !== "section") {
+  while (section.node.get(0) && section.node.get(0).tagName !== "section") {
     section.node = section.node.parent();
   }
   // for section 4, only keep the first subsection


### PR DESCRIPTION
This is a hotfix sugested by @mulder21c on http://blog.publisher.name/ to be able to build HTML 5.1
W3C Recommendation, 1 November 2016, branch html5.1 from https://github.com/w3c/html.

**Possible related: https://github.com/w3c/html/issues/707 (a issue where I had to --force bikeshed to build)**

After this change, it works. The change is minimal, and should not have unexpected side effects.

```shell
# See full logs at https://travis-ci.org/fititnt/html51-translation-testing-hello-world/builds/173450523

git clone --depth=1 --branch=master https://github.com/adrianba/multipage.git ./tools
(...)

node --max_old_space_size=2048 ./tools/multipage.js single-page.html ./out/
This platform is linux node v5.11.1
Loading single-page.html
Creating ID->file mapping
Sorting out sections
/home/travis/build/fititnt/html51-translation-testing-hello-world/tools/multipage.js:119
  while (section.node.get(0).tagName !== "section") {
                            ^

TypeError: Cannot read property 'tagName' of undefined
    at Object.<anonymous> (/home/travis/build/fititnt/html51-translation-testing-hello-world/tools/multipage.js:119:29)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:148:18)
    at node.js:405:3

travis_time:end:09255b6a:start=1478325082177872061,finish=1478325197325670198,duration=115147798137
[0K
[31;1mThe command "bikeshed -f spec && ./.multipage-split.sh" exited with 1.[0m

Done. Your build exited with 1.
```